### PR TITLE
OPS-145: Allow the version number to be in any heading level

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         npm ci
         npm run docusaurus finalize-doc $VERSION
         sed -i "5i \|\[${VERSION}\]\(\#v${VERSION//\./}\)\| \`$(date +'%d %B %Y')\` \|" $RELEASE_NOTES
-        export ln=$(cat $RELEASE_NOTES | grep -n "### v[0-9]\+.[0-9]\+.[0-9]\+" | head -1 | cut -d':' -f1)
+        export ln=$(cat $RELEASE_NOTES | grep -n "#+ v[0-9]\+.[0-9]\+.[0-9]\+" | head -1 | cut -d':' -f1)
         if [ -z "$ln" ]; then
           echo "${changelog}\n\n---\n" >> $RELEASE_NOTES
         else


### PR DESCRIPTION
Signed-off-by: Marcus Koh <marcus.koh@zepben.com>

# Description

This is part of the task that aims to have consistent release notes in the changelog file between EDNAR and non-EDNAR repos. This change supports the change in heading levels for the non-EDNAR repos (h1, h2, h3 instead of h1, h3, h5).

# Associated tasks:

- This task is blocking https://github.com/zepben/ci-utils/pull/4 from being merged.

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added unit tests / updated existing tests for these changes.
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.
- [x] I have commented my code in hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
