### PR TITLE
Use extended regex for grep

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         npm ci
         npm run docusaurus finalize-doc $VERSION
         sed -i "5i \|\[${VERSION}\]\(\#v${VERSION//\./}\)\| \`$(date +'%d %B %Y')\` \|" $RELEASE_NOTES
-        export ln=$(cat $RELEASE_NOTES | grep -n "#+ v[0-9]\+.[0-9]\+.[0-9]\+" | head -1 | cut -d':' -f1)
+        export ln=$(cat $RELEASE_NOTES | grep -E -n "#+ v[0-9]+.[0-9]+.[0-9]+" | head -1 | cut -d':' -f1)
         if [ -z "$ln" ]; then
           echo "${changelog}\n\n---\n" >> $RELEASE_NOTES
         else


### PR DESCRIPTION
Signed-off-by: Marcus Koh <marcus.koh@zepben.com>

# Description

This fixes the issue shown in https://github.com/zepben/gis-network-extractor/commit/ec3a55ab0516864663938919c2770a21056e648e by using extended regex for grep via the `-E` flag.

# Associated tasks:

This task has no blocking tasks, and should be merged before performing a release on any repo that uses this action.

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
