### PR TITLE
Make git tagging optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,13 @@ runs:
         # just in case, add EOL
         echo "\n" >> .npmrc
         cd ..
+
     
+    - uses: actions/cache@v3
+      with:
+        path: docs/node_modules
+        key: node_modules
+
     - shell: sh
       run: |
         # "Build the documentation site"

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
         changelog=$(sed -n -E "/${{ inputs.VERSION }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" ${{ inputs.CHANGELOG_FILE }})
         to_append="$header\n\n$changelog\n\n---\n"
         cd docs
-        sed -i "5i \|\[${{ inputs.VERSION }}\]\(\#v${{ inputs.VERSION }}//\./\)\| \`$(date +'%d %B %Y')\` \|" $inputs.RELEASE_NOTES
+        sed -i "5i \|\[${{ inputs.VERSION }}\]\(\#v${{ inputs.VERSION }}//\./\)\| \`$(date +'%d %B %Y')\` \|" ${{ inputs.RELEASE_NOTES }}
         export ln=$(cat ${{ inputs.RELEASE_NOTES }} | grep -E -n "#+ \[[0-9]+.[0-9]+.[0-9]+" | head -1 | cut -d':' -f1)
         if [ -z "$ln" ]; then
           echo "${changelog}\n\n---\n" >> ${{ inputs.RELEASE_NOTES }}

--- a/action.yml
+++ b/action.yml
@@ -27,17 +27,17 @@ runs:
   using: "composite"
   steps: 
 
-    - name: Checkout the release branch
-      shell: sh
+    - shell: sh
       if: ${{ inputs.TAG-AND-RELEASE == 'yes' }}
       run: |
+        echo "Checkout 'release' branch"
         git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
         git fetch --all
         git checkout release
 
-    - name: Update npmrc
-      shell: sh
+    - shell: sh
       run: |
+        echo "Update npmrc"
         cd docs
         rm -f .npmrc
         echo "@zepben:registry=${{inputs.NPM_REPO}}" >> .npmrc
@@ -46,19 +46,19 @@ runs:
         echo "\n" >> .npmrc
         cd ..
     
-    - name: Build the documentation site
-      shell: sh
+    - shell: sh
       run: |
+        echo "Build the documentation site"
         cd docs
         npm ci
         npm run docusaurus docs:version ${{ inputs.VERSION }}
         npm run build
         cd ..
 
-    - name: Commit the release branch
-      shell: sh
+    - shell: sh
       if: ${{ inputs.TAG-AND-RELEASE == 'yes' }}
       run: |
+        echo "Commit the release branch"
         header="## [${{ inputs.VERSION }}]"
         changelog=$(sed -n -E "/${{ inputs.VERSION }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" ${{ inputs.CHANGELOG_FILE }})
         to_append="$header\n\n$changelog\n\n---\n"

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
 
     - shell: sh
       run: |
-        echo "Update npmrc"
+        # "Update npmrc"
         cd docs
         rm -f .npmrc
         echo "@zepben:registry=${{inputs.NPM_REPO}}" >> .npmrc
@@ -48,7 +48,7 @@ runs:
     
     - shell: sh
       run: |
-        echo "Build the documentation site"
+        # "Build the documentation site"
         cd docs
         npm ci
         npm run docusaurus docs:version ${{ inputs.VERSION }}
@@ -58,7 +58,7 @@ runs:
     - shell: sh
       if: ${{ inputs.TAG-AND-RELEASE == 'yes' }}
       run: |
-        echo "Commit the release branch"
+        # "Commit the release branch"
         header="## [${{ inputs.VERSION }}]"
         changelog=$(sed -n -E "/${{ inputs.VERSION }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" ${{ inputs.CHANGELOG_FILE }})
         to_append="$header\n\n$changelog\n\n---\n"

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   VERSION:
     description: "The project version."
     required: false
-    default: 1.0.0-test 
+    default: 0.0.1-test-ci 
   CHANGELOG_FILE:
     description: "File containing the current changelog."
     default: changelog.md

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: 'Docusaurus Release Action'
 description: 'Build docusaurus project as part of the build process.'
 inputs:
+  TAG-AND-RELEASE:
+    description: 'Whether to git tag and release the docs'
+    default: 'yes' 
+    required: false
   VERSION:
     description: "The project version."
     required: true
@@ -25,6 +29,7 @@ runs:
 
     - name: Checkout the release branch
       shell: sh
+      if: ${{ inputs.TAG-AND-RELEASE }} == 'yes'
       run: |
         git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
         git fetch --all
@@ -35,40 +40,36 @@ runs:
       run: |
         cd docs
         rm -f .npmrc
-        echo "@zepben:registry=${NPM_REPO}" >> .npmrc
-        echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> .npmrc
+        echo "@zepben:registry=${{inputs.NPM_REPO}}" >> .npmrc
+        echo "//npm.pkg.github.com/:_authToken=${{inputs.NPM_TOKEN}}" >> .npmrc
         # just in case, add EOL
         echo "\n" >> .npmrc
         cd ..
-      env:
-        NPM_REPO: ${{ inputs.NPM_REPO }}
-        NPM_TOKEN: ${{ inputs.NPM_TOKEN }}
     
     - name: Build the documentation site
       shell: sh
       run: |
         cd docs
         npm ci
-        npm run docusaurus docs:version $VERSION
+        npm run docusaurus docs:version ${{ inputs.VERSION }}
         npm run build
         cd ..
-      env:
-        VERSION: ${{ inputs.VERSION }}
 
     - name: Commit the release branch
       shell: sh
+      if: ${{ inputs.tag-and-release }} == 'yes'
       run: |
-        header="## [$VERSION]"
-        changelog=$(sed -n -E "/$VERSION/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" $CHANGELOG_FILE)
+        header="## [${{ inputs.VERSION }}]"
+        changelog=$(sed -n -E "/${{ inputs.VERSION }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" ${{ inputs.CHANGELOG_FILE }})
         to_append="$header\n\n$changelog\n\n---\n"
         cd docs
-        sed -i "5i \|\[${VERSION}\]\(\#v${VERSION//\./}\)\| \`$(date +'%d %B %Y')\` \|" $RELEASE_NOTES
-        export ln=$(cat $RELEASE_NOTES | grep -E -n "#+ \[[0-9]+.[0-9]+.[0-9]+" | head -1 | cut -d':' -f1)
+        sed -i "5i \|\[${{ inputs.VERSION }}\]\(\#v${{ inputs.VERSION }}//\./\)\| \`$(date +'%d %B %Y')\` \|" $inputs.RELEASE_NOTES
+        export ln=$(cat ${{ inputs.RELEASE_NOTES }} | grep -E -n "#+ \[[0-9]+.[0-9]+.[0-9]+" | head -1 | cut -d':' -f1)
         if [ -z "$ln" ]; then
-          echo "${changelog}\n\n---\n" >> $RELEASE_NOTES
+          echo "${changelog}\n\n---\n" >> ${{ inputs.RELEASE_NOTES }}
         else
-          awk -v n=$ln -v s="$to_append" 'NR == n {print s} {print}' $RELEASE_NOTES > release-notes.tmp
-          mv release-notes.tmp $RELEASE_NOTES
+          awk -v n=$ln -v s="$to_append" 'NR == n {print s} {print}' ${{ inputs.RELEASE_NOTES }} > release-notes.tmp
+          mv release-notes.tmp ${{ inputs.RELEASE_NOTES }}
         fi
         git restore .npmrc
         git add .
@@ -76,9 +77,3 @@ runs:
         git config user.name "Github CI"
         git commit -m "Committing doc changes to docusaurus. [skip ci]"
         git push origin release
-      env:
-        VERSION: ${{ inputs.VERSION }}
-        CHANGELOG_FILE: ${{ inputs.CHANGELOG_FILE  }}
-        RELEASE_NOTES: ${{ inputs.RELEASE_NOTES }}
-        NPM_REPO: ${{ inputs.NPM_REPO }}
-        NPM_TOKEN: ${{ inputs.NPM_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
     - shell: sh
       if: ${{ inputs.TAG-AND-RELEASE == 'yes' }}
       run: |
-        echo "Checkout 'release' branch"
+        # "Checkout 'release' branch"
         git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
         git fetch --all
         git checkout release

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
 
     - name: Checkout the release branch
       shell: sh
-      if: ${{ inputs.TAG-AND-RELEASE }} == 'yes'
+      if: ${{ inputs.TAG-AND-RELEASE == 'yes' }}
       run: |
         git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
         git fetch --all
@@ -57,7 +57,7 @@ runs:
 
     - name: Commit the release branch
       shell: sh
-      if: ${{ inputs.TAG-AND-RELEASE }} == 'yes'
+      if: ${{ inputs.TAG-AND-RELEASE == 'yes' }}
       run: |
         header="## [${{ inputs.VERSION }}]"
         changelog=$(sed -n -E "/${{ inputs.VERSION }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" ${{ inputs.CHANGELOG_FILE }})

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,8 @@ inputs:
     required: false
   VERSION:
     description: "The project version."
-    required: true
+    required: false
+    default: 1.0.0-test 
   CHANGELOG_FILE:
     description: "File containing the current changelog."
     default: changelog.md

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
 
     - name: Commit the release branch
       shell: sh
-      if: ${{ inputs.tag-and-release }} == 'yes'
+      if: ${{ inputs.TAG-AND-RELEASE }} == 'yes'
       run: |
         header="## [${{ inputs.VERSION }}]"
         changelog=$(sed -n -E "/${{ inputs.VERSION }}/,/## [[0-9]+\.[0-9]+\.[0-9]+]/ { /## \[/d;p }" ${{ inputs.CHANGELOG_FILE }})


### PR DESCRIPTION
# Description

Improvements to running the docusaurus action:

* Remove repeated env reinitialisation and use inputs directly
* Remove the check for the docs directory
* Add comments at the beginning of the 'run' calls to make the output more readable.
* Add an optional `TAG-AND-RELEASE` input to be able to run this action for both just build and for the git-tag/release actions. This will allow to get rid of all `-release-with-docs` workflows.
* Make VERSION input optional so that builds without release won't need to provide one.
