### PR TITLE
Tag version before building

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,13 @@ runs:
         echo "\n" >> .npmrc
         cd ..
 
+    - shell: sh
+      if: ${{ inputs.TAG == 'yes' }}
+      run: |
+        # "VERSION TAG the new documentation"
+        cd docs
+        npm run docusaurus docs:version ${{ inputs.VERSION }}
+        cd ..
 
     - shell: sh
       run: |
@@ -54,14 +61,6 @@ runs:
         cd docs
         npm ci
         npm run build
-        cd ..
-
-    - shell: sh
-      if: ${{ inputs.TAG == 'yes' }}
-      run: |
-        # "VERSION TAG the new documentation"
-        cd docs
-        npm run docusaurus docs:version ${{ inputs.VERSION }}
         cd ..
 
     - shell: sh


### PR DESCRIPTION
# Description

When we tag version, the new version entry is created in the `versioned_docs` folder; and when running build, the result is placed in the `build` folder. Hence, if we *build* before tagging, the build will not include the new version.

This fix switches the order of the steps to tag first and then build, hence including the new tagged version in the build folder.  

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
~- [ ] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
~- [ ] I have considered if this is a breaking change and will communicate it with other team members if so.~