### PR TITLE
[OPS-469] Restoring the copy out to the build step so it always runs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -127,6 +127,12 @@ runs:
       run: |
         pushd "${site}"
         npm run build
+
+        # Finally, we can copy out the build directory from site-config if in docusaurus3, so that zipper can do its thing
+        if [ $(basename $(pwd)) == "site-config" ]; then
+          mv build ..
+        fi
+
         popd
 
     - name: Commit the results
@@ -141,9 +147,6 @@ runs:
           \cp -frL site-config/versioned_docs/* archive/versioned_docs/
           \cp -frL site-config/versioned_sidebars/* archive/versioned_sidebars/
           \cp -rf site-config/versions.json archive/
-
-          # Finally, we can copy out the build directory from site-config if in docusaurus3, so that zipper can do its thing
-          mv site-config/build .
 
           # restore .npmrc
           git restore site-config/.npmrc


### PR DESCRIPTION
# Description

Copy out the `build` artefact from D3 at the build stage rather than the commit stage. The commit stage only happens in `release` flows, so this will restore it to work in `snapshot` ones as well.